### PR TITLE
Frontend README change from npm to yarn

### DIFF
--- a/gatsby/README.md
+++ b/gatsby/README.md
@@ -1,7 +1,7 @@
 ## Gatsby
 Install Gatsby CLI
 - `yarn global add gatsby-cli`
-
-Run dev server
+Install dependencies
 - `yarn install`
+Run dev server
 - `yarn dev`


### PR DESCRIPTION
Changed npm to yarn in README file for frontend