### PR TITLE
improved title readability on a mobile platform

### DIFF
--- a/gatsby/src/components/main-background/main-background.module.scss
+++ b/gatsby/src/components/main-background/main-background.module.scss
@@ -5,4 +5,5 @@
   width: 100%;
   display: block;
   z-index: 0;
+  min-height: 250px;
 }


### PR DESCRIPTION
W/o having the minimal image height its bottom can be in the middle of the title text, which decreases title readability.