### PR TITLE
feat(gatsby): add UI component for search results

### DIFF
--- a/gatsby/src/components/search-results/index.tsx
+++ b/gatsby/src/components/search-results/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './search-results';

--- a/gatsby/src/components/search-results/search-results.module.scss
+++ b/gatsby/src/components/search-results/search-results.module.scss
@@ -1,0 +1,26 @@
+@import '../../../assets/scss/design-system/base/variables';
+
+.search-results-title {
+  font-size: 1.8rem;
+  font-weight: 500;
+  line-height: (21/18);
+  margin-bottom: 0.9rem;
+}
+
+.search-results-link {
+  text-decoration: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+
+  &:hover,
+  &:focus,
+  &:visited:hover,
+  &:visited:focus {
+    color: $theme-yellow !important;
+  }
+}
+
+.search-results-desc {
+  margin-bottom: 0;
+}

--- a/gatsby/src/components/search-results/search-results.module.scss.d.ts
+++ b/gatsby/src/components/search-results/search-results.module.scss.d.ts
@@ -1,0 +1,3 @@
+export const searchResultsTitle: string;
+export const searchResultsLink: string;
+export const searchResultsDesc: string;

--- a/gatsby/src/components/search-results/search-results.tsx
+++ b/gatsby/src/components/search-results/search-results.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ContentBox from '@/components/content-box';
+import styles from './search-results.module.scss';
+import { KeyboardArrowRight } from '@material-ui/icons';
+
+interface Props {
+  results: Array<{ title: string; href: string; text: string }>;
+}
+
+const SearchResults: React.FC<Props> = ({ results }) => {
+  return (
+    <>
+      {results.map((result, index) => {
+        return (
+          <ContentBox key={index} variant="white">
+            <h3 className={styles.searchResultsTitle}>
+              <a href={result.href} className={styles.searchResultsLink}>
+                {result.title}
+                <KeyboardArrowRight
+                  style={{ fontSize: 20 }}
+                  className="color-yellow"
+                />
+              </a>
+            </h3>
+            {/* TODO: breadcrumbs */}
+            <p className={styles.searchResultsDesc}>{result.text}</p>
+          </ContentBox>
+        );
+      })}
+      ;
+    </>
+  );
+};
+
+export default SearchResults;


### PR DESCRIPTION
- UI for search results
- consumes data like:
```
results = [
  {
    title: 'title',
    href: 'url',
    text: 'description'
  },{
    ...
  }
]
```
It might be tweaked for the data available.

Didn't prepare breadcrumbs, they're part of different ticket. Can be added later.

Couldn't do last check, my local build is failing and i don't have space to fix it at the moment.