### PR TITLE
gatbsy/fix: external link icon displayed as pseudo after instead of before

### DIFF
--- a/gatsby/assets/scss/design-system/base/_master.scss
+++ b/gatsby/assets/scss/design-system/base/_master.scss
@@ -439,10 +439,12 @@ a {
 		display: inline-block;
 		position: relative;
 
-		&::before {
+		&::before, &::after {
 			@include icon-mix();
 			color: $theme-yellow;
 			@include font-size(10);
+		}
+		&::before {
 			position: absolute;
 			top: 50%;
 			margin-top: -( 10px / 2 );
@@ -489,7 +491,6 @@ a {
 		padding-right: ( $spacer / 6 );
 	}
 
-	&.external,
 	&.more {
 		padding-right: ( $spacer / 3 );
 
@@ -507,7 +508,8 @@ a {
 	}
 
 	&.external {
-		&::before {
+		&::after {
+			margin-left: ( $spacer / 6 );
 			content: '\e909';
 		}
 	}


### PR DESCRIPTION
external link icon displayed as pseudo `::after` instead of `::before`

Not sure if this is the right file to make the change or we should rather override the design system..?

Solves:
https://trello.com/c/uVTwPnQW/214-pati%C4%8Dka-ikonka-extern%C3%ADho-odkazu-zarovnat-s-prvn%C3%ADm-%C5%99%C3%A1dkem