### PR TITLE
gatsby - Measure and Situation component separation

### DIFF
--- a/gatsby/src/components/measure-detail/index.tsx
+++ b/gatsby/src/components/measure-detail/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './measure-detail';

--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import { Room, Event } from '@material-ui/icons';
+
+import Time from '@/components/time';
+import I18n from '@/components/i18n';
+
+import { IMeasureDetailFragment } from 'graphql-types';
+import { graphql } from 'gatsby';
+import TopicDetail from '../topic-detail';
+
+interface IProps {
+  measure: IMeasureDetailFragment;
+}
+
+const MeasureDetail: React.FC<IProps> = ({ measure }) => {
+  return (
+    <TopicDetail
+      breadcrumbItems={[
+        { title: I18n('home'), url: '/' },
+        {
+          title: I18n('current_measures'),
+          url: I18n(`slug_measures`),
+        },
+        {
+          title: measure.relationships?.situation_type?.name,
+          url: measure.relationships?.situation_type?.path?.alias,
+        },
+        measure.title,
+      ]}
+      title={measure.title}
+      processedContent={measure?.content?.processed}
+    >
+      {measure.relationships.region.length ? (
+        <div className="mt-2">
+          <h3 className="mb-1 color-blue-dark">{I18n('location_validity')}</h3>
+          <div className="d-flex align-items-center color-blue mb-1">
+            <Room />
+            &nbsp;
+            <span className="text-uppercase font-weight-medium">
+              {measure.relationships.region.map((item) => item.name).join(', ')}
+            </span>
+          </div>
+        </div>
+      ) : (
+        ''
+      )}
+
+      {measure.valid_from || measure.valid_to ? (
+        <div className="d-flex align-items-center color-blue">
+          <Event />
+          &nbsp;
+          <span className="text-uppercase font-weight-medium">
+            {measure.valid_from && (
+              <Time datetime={measure.valid_from} prefix={`${I18n('from')} `} />
+            )}
+
+            {measure.valid_to && (
+              <Time datetime={measure.valid_to} prefix={`${I18n('to')} `} />
+            )}
+          </span>
+        </div>
+      ) : (
+        ''
+      )}
+    </TopicDetail>
+  );
+};
+
+export const query = graphql`
+  fragment MeasureDetail on measure {
+    title
+    content: description {
+      processed
+    }
+    links: source {
+      uri
+      title
+    }
+    relationships {
+      region {
+        name
+      }
+      situation_type: field_measure_type {
+        name
+        path {
+          alias
+        }
+      }
+      related_situations: situation {
+        title
+      }
+    }
+    path {
+      alias
+    }
+    changed
+    valid_from
+    valid_to
+  }
+`;
+
+export default MeasureDetail;

--- a/gatsby/src/components/situation-detail/situation-detail.module.scss.d.ts
+++ b/gatsby/src/components/situation-detail/situation-detail.module.scss.d.ts
@@ -1,1 +1,0 @@
-export const situationDetail: string;

--- a/gatsby/src/components/situation-detail/situation-detail.scss.d.ts
+++ b/gatsby/src/components/situation-detail/situation-detail.scss.d.ts
@@ -1,1 +1,0 @@
-export const situationDetail: string;

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -4,128 +4,96 @@ import { Room, Event } from '@material-ui/icons';
 
 import Container from '@/components/container';
 import Link from '@/components/link';
-import Breadcrumb from '@/components/breadcrumb';
-import Headline from '@/components/headline';
 import Time from '@/components/time';
 import I18n from '@/components/i18n';
 
-import styles from './situation-detail.module.scss';
 import Accordion from '../accordion';
 import ContentBox from '../content-box';
-import { ISituation } from '../../../graphql-types';
-
-interface Region {
-  name: string;
-}
-
-interface Link {
-  uri: string;
-  title?: string;
-}
+import { ISituationDetailFragment } from 'graphql-types';
+import { graphql } from 'gatsby';
+import TopicDetail from '../topic-detail';
 
 interface IProps {
-  situation: ISituation;
-  type: string;
+  situation: ISituationDetailFragment;
 }
 
-const SituationDetail: React.FC<IProps> = ({ situation, type }) => {
+const SituationDetail: React.FC<IProps> = ({ situation }) => {
   return (
-    <div className={styles.situationDetail}>
-      <Container>
-        <div className="pt-1">
-          <Breadcrumb
-            items={[
-              { title: I18n('home'), url: '/' },
-              {
-                title: I18n(
-                  type === 'measure' ? 'current_measures' : 'life_situations',
-                ),
-                url: I18n(`slug_${type}s`),
-              },
-              {
-                title: situation.relationships?.situation_type?.name,
-                url: situation.relationships?.situation_type?.path?.alias,
-              },
-              situation.title,
-            ]}
-            variant="inverse"
-          />
-        </div>
-        <div className="mt-3">
-          <Headline>{situation.title}</Headline>
-        </div>
-        <article className="bg-white rounded p-2 pb-3 mb-1">
-          <div
-            dangerouslySetInnerHTML={{
-              __html: situation?.content?.processed,
-            }}
-          />
-
-          {situation.links?.length ? (
-            <div className="mt-2">
-              <h3 className="mb-1 color-blue-dark">{I18n('related')}</h3>
-              <div>
-                {situation.links.map((link, index) => (
-                  <div key={index}>
-                    <Link className="color-blue mb-1" to={link.uri}>
-                      {link.title}
-                    </Link>
-                  </div>
-                ))}
-              </div>
+    <>
+      <TopicDetail
+        breadcrumbItems={[
+          { title: I18n('home'), url: '/' },
+          {
+            title: I18n('life_situations'),
+            url: I18n(`slug_situations`),
+          },
+          {
+            title: situation.relationships?.situation_type?.name,
+            url: situation.relationships?.situation_type?.path?.alias,
+          },
+          situation.title,
+        ]}
+        title={situation.title}
+        processedContent={situation?.content?.processed}
+      >
+        {situation.links.length ? (
+          <div className="mt-2">
+            <h3 className="mb-1 color-blue-dark">{I18n('related')}</h3>
+            <div>
+              {situation.links.map((link, index) => (
+                <div key={index}>
+                  <Link className="color-blue mb-1" to={link.uri}>
+                    {link.title}
+                  </Link>
+                </div>
+              ))}
             </div>
-          ) : (
-            ''
-          )}
+          </div>
+        ) : (
+          ''
+        )}
 
-          {situation.relationships?.region.length ? (
-            <div className="mt-2">
-              <h3 className="mb-1 color-blue-dark">
-                {I18n('location_validity')}
-              </h3>
-              <div className="d-flex align-items-center color-blue mb-1">
-                <Room />
-                &nbsp;
-                <span className="text-uppercase font-weight-medium">
-                  {situation.relationships.region
-                    .map((item) => item.name)
-                    .join(', ')}
-                </span>
-              </div>
-            </div>
-          ) : (
-            ''
-          )}
-
-          {situation.valid_from || situation.valid_to ? (
-            <div className="d-flex align-items-center color-blue">
-              <Event />
+        {situation.relationships?.region.length ? (
+          <div className="mt-2">
+            <h3 className="mb-1 color-blue-dark">
+              {I18n('location_validity')}
+            </h3>
+            <div className="d-flex align-items-center color-blue mb-1">
+              <Room />
               &nbsp;
               <span className="text-uppercase font-weight-medium">
-                {situation.valid_from && (
-                  <Time
-                    datetime={situation.valid_from}
-                    prefix={`${I18n('from')} `}
-                  />
-                )}
-
-                {situation.valid_to && (
-                  <Time
-                    datetime={situation.valid_to}
-                    prefix={`${I18n('to')} `}
-                  />
-                )}
+                {situation.relationships.region
+                  .map((item) => item.name)
+                  .join(', ')}
               </span>
             </div>
-          ) : (
-            ''
-          )}
+          </div>
+        ) : (
+          ''
+        )}
 
-          {/* <p className="mt-2 text-muted font-italic">
-            Naposledy bylo toto téma aktualizováno {situation.changed}
-          </p> */}
-        </article>
+        {situation.valid_from || situation.valid_to ? (
+          <div className="d-flex align-items-center color-blue">
+            <Event />
+            &nbsp;
+            <span className="text-uppercase font-weight-medium">
+              {situation.valid_from && (
+                <Time
+                  datetime={situation.valid_from}
+                  prefix={`${I18n('from')} `}
+                />
+              )}
 
+              {situation.valid_to && (
+                <Time datetime={situation.valid_to} prefix={`${I18n('to')} `} />
+              )}
+            </span>
+          </div>
+        ) : (
+          ''
+        )}
+      </TopicDetail>
+      <Container>
         {situation.questions_answers?.length ? (
           // TODO: localize
           <ContentBox variant="blue" title={I18n('faq')} boldedTitleCount={2}>
@@ -140,8 +108,42 @@ const SituationDetail: React.FC<IProps> = ({ situation, type }) => {
           ''
         )}
       </Container>
-    </div>
+    </>
   );
 };
+
+export const query = graphql`
+  fragment SituationDetail on situation {
+    title
+    content {
+      processed
+    }
+    links {
+      uri
+      title
+    }
+    relationships {
+      region {
+        name
+      }
+      situation_type {
+        name
+        path {
+          alias
+        }
+      }
+    }
+    path {
+      alias
+    }
+    questions_answers {
+      question
+      value
+    }
+    changed
+    valid_from
+    valid_to
+  }
+`;
 
 export default SituationDetail;

--- a/gatsby/src/components/topic-detail/index.tsx
+++ b/gatsby/src/components/topic-detail/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './topic-detail';

--- a/gatsby/src/components/topic-detail/topic-detail.module.scss
+++ b/gatsby/src/components/topic-detail/topic-detail.module.scss
@@ -1,4 +1,4 @@
-.situationDetail {
+.topicDetail {
   h2 {
     font-weight: 500;
   }

--- a/gatsby/src/components/topic-detail/topic-detail.module.scss.d.ts
+++ b/gatsby/src/components/topic-detail/topic-detail.module.scss.d.ts
@@ -1,0 +1,1 @@
+export const topicDetail: string;

--- a/gatsby/src/components/topic-detail/topic-detail.tsx
+++ b/gatsby/src/components/topic-detail/topic-detail.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import Container from '@/components/container';
+import Breadcrumb from '@/components/breadcrumb';
+import Headline from '@/components/headline';
+
+import styles from './topic-detail.module.scss';
+
+interface IProps {
+  breadcrumbItems: React.ComponentProps<typeof Breadcrumb>['items'];
+  title: string;
+  processedContent: string;
+}
+
+const TopicDetail: React.FC<IProps> = ({
+  breadcrumbItems,
+  title,
+  processedContent,
+  children,
+}) => {
+  return (
+    <div className={styles.topicDetail}>
+      <Container>
+        <div className="pt-1">
+          <Breadcrumb items={breadcrumbItems} variant="inverse" />
+        </div>
+        <div className="mt-3">
+          <Headline>{title}</Headline>
+        </div>
+        <article className="bg-white rounded p-2 pb-3 mb-1">
+          <div
+            dangerouslySetInnerHTML={{
+              __html: processedContent,
+            }}
+          />
+          {children}
+        </article>
+      </Container>
+    </div>
+  );
+};
+
+export default TopicDetail;

--- a/gatsby/src/templates/lists/measures.tsx
+++ b/gatsby/src/templates/lists/measures.tsx
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby';
 import ContentBox from '@/components/content-box';
 import Container from '@/components/container';
 import { SEO as Seo } from 'gatsby-plugin-seo';
-import { IQuery } from 'graphql-types';
+import { IMeasureTypeQueryQuery } from 'graphql-types';
 import Breadcrumb from '@/components/breadcrumb';
 import Headline from '@/components/headline';
 import CategoryItem from '@/components/category-item';
@@ -11,7 +11,7 @@ import Layout from '@/layouts/default-layout';
 import I18n from '@/components/i18n';
 
 interface IProps {
-  data: IQuery;
+  data: IMeasureTypeQueryQuery;
 }
 
 const Measures: React.FC<IProps> = ({ data }) => {
@@ -19,7 +19,7 @@ const Measures: React.FC<IProps> = ({ data }) => {
     allTaxonomyTermMeasureType: { nodes },
   } = data;
 
-  const { searchingTitle } = data as any;
+  const { searchingTitle } = data;
 
   // todo add meta description
   return (

--- a/gatsby/src/templates/lists/situations.tsx
+++ b/gatsby/src/templates/lists/situations.tsx
@@ -3,7 +3,7 @@ import { SEO as Seo } from 'gatsby-plugin-seo';
 import { graphql } from 'gatsby';
 import ContentBox from '@/components/content-box';
 import Container from '@/components/container';
-import { IQuery } from 'graphql-types';
+import { ISituationTypeQueryQuery } from 'graphql-types';
 import Breadcrumb from '@/components/breadcrumb';
 import Headline from '@/components/headline';
 import CategoryItem from '@/components/category-item';
@@ -12,14 +12,14 @@ import Layout from '@/layouts/default-layout';
 import I18n from '@/components/i18n';
 
 interface IProps {
-  data: IQuery;
+  data: ISituationTypeQueryQuery;
 }
 
 const Situations: React.FC<IProps> = ({ data }) => {
   const {
     allArea: { nodes },
   } = data;
-  const { searchingTitle } = data as any;
+  const { searchingTitle } = data;
 
   // todo: add meta description
   return (
@@ -98,6 +98,7 @@ export const query = graphql`
       source: { eq: "still_searching_title" }
     ) {
       target
+      langcode
     }
     searchingDescription: translation(
       langcode: { eq: $langCode }

--- a/gatsby/src/templates/measures/page.tsx
+++ b/gatsby/src/templates/measures/page.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { IQuery } from 'graphql-types';
+import { IMeasurePageQueryQuery } from 'graphql-types';
 import { SchemaComp } from '@/components/schema/schema';
 import { SEO as Seo } from 'gatsby-plugin-seo';
-import SituationDetail from '@/components/situation-detail';
 import Layout from '@/layouts/default-layout';
 import I18n from '@/components/i18n';
+import MeasureDetail from '@/components/measure-detail';
 interface IProps {
-  data: IQuery;
+  data: IMeasurePageQueryQuery;
 }
 
 const Page: React.FC<IProps> = ({ data }) => {
@@ -28,8 +28,8 @@ const Page: React.FC<IProps> = ({ data }) => {
         defaultTitle={data.measure.title}
         isBlogPost
         body={
-          (data.measure as any).content
-            ? (data.measure as any).content.processed
+          data.measure.content
+            ? data.measure.content.processed
             : data.measure.meta_description
         }
         description={data.measure.meta_description}
@@ -40,45 +40,26 @@ const Page: React.FC<IProps> = ({ data }) => {
           name: 'Portál veřejné správy',
         }}
       />
-      <SituationDetail situation={data.measure} type="measure" />
+      <MeasureDetail measure={data.measure} />
     </Layout>
   );
 };
 export default Page;
 
 export const query = graphql`
-  query($slug: String!) {
+  query MeasurePageQuery($slug: String!) {
     measure(path: { alias: { eq: $slug } }) {
       title
-      status
+      meta_description
       content: description {
         processed
-      }
-      links: source {
-        uri
-        title
-      }
-      relationships {
-        region {
-          name
-        }
-        situation_type: field_measure_type {
-          name
-          path {
-            alias
-          }
-        }
-        related_situations: situation {
-          title
-        }
       }
       path {
         alias
       }
       langcode
-      changed
       valid_from
-      valid_to
+      ...MeasureDetail
     }
   }
 `;

--- a/gatsby/src/templates/situations/page.tsx
+++ b/gatsby/src/templates/situations/page.tsx
@@ -41,7 +41,7 @@ const Page: React.FC<IProps> = ({ data }) => {
           name: 'Portál veřejné správy',
         }}
       />
-      <SituationDetail situation={data.situation} type="situation" />
+      <SituationDetail situation={data.situation} />
       <Container className="pt-1">
         {/* hide this box if no relevant topics exist */}
         {linksData.length > 0 ? (


### PR DESCRIPTION
- using GraphQL fragments for better data collocation + TS types (up until now it worked mainly because of aliases)
- separated SituationDetail and MeasureDetails as both use different data
- created TopicDetail for the similiar parts of Situation and Detail
- removed several `any`s from the code (some data were previously actually missing - not fetched from graphql)