### PR TITLE
gatsby: Add subtitle to Measure detail page

### DIFF
--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -29,6 +29,7 @@ const MeasureDetail: React.FC<IProps> = ({ measure }) => {
         measure.title,
       ]}
       title={measure.title}
+      subtitle={measure.norm}
       processedContent={measure?.content?.processed}
     >
       {measure.relationships.region.length ? (
@@ -70,6 +71,7 @@ const MeasureDetail: React.FC<IProps> = ({ measure }) => {
 export const query = graphql`
   fragment MeasureDetail on measure {
     title
+    norm
     content: description {
       processed
     }

--- a/gatsby/src/components/subtitle/index.tsx
+++ b/gatsby/src/components/subtitle/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './subtitle';

--- a/gatsby/src/components/subtitle/subtitle.module.scss
+++ b/gatsby/src/components/subtitle/subtitle.module.scss
@@ -1,0 +1,5 @@
+.subtitle {
+  font-size: 1.7rem;
+  margin-bottom: 2.2rem;
+  color: black;
+}

--- a/gatsby/src/components/subtitle/subtitle.module.scss.d.ts
+++ b/gatsby/src/components/subtitle/subtitle.module.scss.d.ts
@@ -1,0 +1,1 @@
+export const subtitle: string;

--- a/gatsby/src/components/subtitle/subtitle.tsx
+++ b/gatsby/src/components/subtitle/subtitle.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './subtitle.module.scss';
+
+const Subtitle: React.FC<{ className?: string }> = ({
+  children,
+  className,
+}) => {
+  return <p className={classNames(styles.subtitle, className)}>{children}</p>;
+};
+
+export default Subtitle;

--- a/gatsby/src/components/topic-detail/topic-detail.tsx
+++ b/gatsby/src/components/topic-detail/topic-detail.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Container from '@/components/container';
 import Breadcrumb from '@/components/breadcrumb';
 import Headline from '@/components/headline';
+import Subtitle from '@/components/subtitle';
 
 import styles from './topic-detail.module.scss';
 
@@ -10,6 +11,7 @@ interface IProps {
   breadcrumbItems: React.ComponentProps<typeof Breadcrumb>['items'];
   title: string;
   processedContent: string;
+  subtitle?: string;
 }
 
 const TopicDetail: React.FC<IProps> = ({
@@ -17,6 +19,7 @@ const TopicDetail: React.FC<IProps> = ({
   title,
   processedContent,
   children,
+  subtitle,
 }) => {
   return (
     <div className={styles.topicDetail}>
@@ -28,6 +31,7 @@ const TopicDetail: React.FC<IProps> = ({
           <Headline>{title}</Headline>
         </div>
         <article className="bg-white rounded p-2 pb-3 mb-1">
+          {subtitle && <Subtitle>{subtitle}</Subtitle>}
           <div
             dangerouslySetInnerHTML={{
               __html: processedContent,


### PR DESCRIPTION
Added the norm to the Measure detail page.

Decided to make it part of the content, for some of the measures, especially with longer norms, it looked super weird to have it just under the H1 above the content.

This is my first PR into this project, not sure if I missed anything or not, so I'm open to any criticism :))

Not sure if there is a design somewhere, I just rolled with what my eyes told me. 

![image](https://user-images.githubusercontent.com/2070479/98444231-cdbf6d00-2110-11eb-9114-dd4d33768329.png)
