### PR TITLE
Gatsby: list-card desktop styles

### DIFF
--- a/gatsby/src/components/list-card/list-card.tsx
+++ b/gatsby/src/components/list-card/list-card.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Button from '@/components/button';
 import Link from '@/components/link';
 import I18n from '@/components/i18n';
+import styles from './measure-list-card.module.scss';
+import classNames from 'classnames';
 
 interface IProps {
   title: string;
@@ -10,11 +12,17 @@ interface IProps {
 }
 
 const ListCard: React.FC<IProps> = ({ title, description, link }) => (
-  <Link to={link} className="card p-2 mb-2  text-decoration-none">
+  <Link
+    to={link}
+    className={classNames(
+      'card p-2 mb-2 text-decoration-none',
+      styles.listItem,
+    )}
+  >
     <h2 className="font-weight-medium mb-1">{title}</h2>
     <div className="d-flex justify-content-between align-items-end">
       <p className="m-0 color-gray">{description}</p>
-      <div>
+      <div className={styles.buttonWrapper}>
         <Button text={I18n('detail')} variant="outline" />
       </div>
     </div>

--- a/gatsby/src/components/list-card/measure-list-card.module.scss
+++ b/gatsby/src/components/list-card/measure-list-card.module.scss
@@ -10,7 +10,7 @@
   color: #2362a2;
 }
 
-@include media-breakpoint-up(xl) {
+@include media-breakpoint-up(lg) {
   .listItem {
     margin-bottom: 0 !important;
     border-radius: 0;

--- a/gatsby/src/components/list-card/measure-list-card.module.scss
+++ b/gatsby/src/components/list-card/measure-list-card.module.scss
@@ -1,6 +1,44 @@
+@import '../../../assets/scss/design-system/base/variables';
+@import '../../../assets/scss/design-system/vendor/bootstrap/functions';
+@import '../../../assets/scss/design-system/vendor/bootstrap/mixins';
+@import '../../../assets/scss/design-system/vendor/bootstrap/variables';
+
 .measure-list-card-detail {
   font-size: 1.3rem;
   line-height: 2rem;
   font-weight: 500;
   color: #2362a2;
+}
+
+@include media-breakpoint-up(xl) {
+  .listItem {
+    margin-bottom: 0 !important;
+    border-radius: 0;
+    border-color: transparent;
+    border-bottom-color: #c7d5e1;
+    position: relative;
+
+    &:last-child {
+      border-bottom-color: transparent;
+    }
+
+    h2 {
+      font-weight: 400;
+      color: #2362a2;
+      font-size: 18px;
+      line-height: 32px;
+
+      &:after {
+        content: '\E912';
+        font-family: 'pvs-icons' !important;
+        color: $theme-yellow;
+        float: right;
+        font-size: 12px;
+        line-height: 32px;
+      }
+    }
+  }
+  .buttonWrapper {
+    display: none;
+  }
 }

--- a/gatsby/src/components/list-card/measure-list-card.module.scss.d.ts
+++ b/gatsby/src/components/list-card/measure-list-card.module.scss.d.ts
@@ -1,1 +1,3 @@
 export const measureListCardDetail: string;
+export const listItem: string;
+export const buttonWrapper: string;

--- a/gatsby/src/components/list-card/measure-list-card.tsx
+++ b/gatsby/src/components/list-card/measure-list-card.tsx
@@ -4,6 +4,7 @@ import Link from '@/components/link';
 import I18n from '@/components/i18n';
 import Time from '@/components/time';
 import styles from './measure-list-card.module.scss';
+import classNames from 'classnames';
 
 interface IProps {
   title: string;
@@ -23,7 +24,13 @@ const MeasureListCard: React.FC<IProps> = ({
   validTo,
 }) => {
   return (
-    <Link to={link} className="card p-2 mb-2 text-decoration-none">
+    <Link
+      to={link}
+      className={classNames(
+        'card p-2 mb-2 text-decoration-none',
+        styles.listItem,
+      )}
+    >
       {/* TODO: Add icon */}
       <h2 className="font-weight-medium mb-1">{title}</h2>
       <p className="mt-0 color-gray">{description}</p>
@@ -39,7 +46,7 @@ const MeasureListCard: React.FC<IProps> = ({
             {validTo && <Time datetime={validTo} prefix={`${I18n('to')} `} />}
           </div>
         </div>
-        <div>
+        <div className={styles.buttonWrapper}>
           <Button text={I18n('detail')} variant="outline" />
         </div>
       </div>


### PR DESCRIPTION
Desktop styles for list-card component as per design here:
https://www.figma.com/file/9avjIglqc1VVc84zHIoLha/CovidPortal?node-id=1045%3A12637

![image](https://user-images.githubusercontent.com/2070479/98465298-8dbbc100-21c8-11eb-9962-fd60d4108184.png)
![image](https://user-images.githubusercontent.com/2070479/98465309-9a401980-21c8-11eb-895c-592487731a39.png)
