### PR TITLE
fix(gatsby): ordering on measures/situations detail lists

### DIFF
--- a/gatsby/src/templates/measures/list.tsx
+++ b/gatsby/src/templates/measures/list.tsx
@@ -18,6 +18,11 @@ interface IProps {
 // todo add meta description
 const Home: React.FC<IProps> = ({ data, pageContext }) => {
   const { taxonomyTermMeasureType } = data;
+  const measures = taxonomyTermMeasureType.relationships?.measure || [];
+
+  const collator = new Intl.Collator([pageContext.langCode]);
+  measures.sort((a, b) => collator.compare(a.title, b.title));
+
   return (
     <Layout pageContext={pageContext}>
       <Seo
@@ -47,7 +52,7 @@ const Home: React.FC<IProps> = ({ data, pageContext }) => {
           <Headline>{taxonomyTermMeasureType.name}</Headline>
         </div>
         <div>
-          {taxonomyTermMeasureType.relationships?.measure?.map((m) => (
+          {measures.map((m) => (
             <MeasureListCard
               key={`taxonomyTermMeasureType-list-item-${m.id}`}
               title={m.title}

--- a/gatsby/src/templates/situations/list.tsx
+++ b/gatsby/src/templates/situations/list.tsx
@@ -18,6 +18,11 @@ interface IProps {
 
 const SituationList: React.FC<IProps> = ({ data, pageContext }) => {
   const { area } = data;
+  const situations = area.relationships?.situation || [];
+
+  const collator = new Intl.Collator([pageContext.langCode]);
+  situations.sort((a, b) => collator.compare(a.title, b.title));
+
   return (
     <Layout pageContext={pageContext}>
       <Seo
@@ -50,7 +55,7 @@ const SituationList: React.FC<IProps> = ({ data, pageContext }) => {
           <Headline>{area.name}</Headline>
         </div>
         <div>
-          {area.relationships?.situation?.map(
+          {situations.map(
             ({ id, title, meta_description, path }) => {
               return (
                 <ListCard


### PR DESCRIPTION
* same problem as in #254 (GraphQL ordering without respected locale)
* https://covid-gov-cz-git-gatsby-fixdetail-list-ordering.ceskodigital.vercel.app/situace/kompenzace