### PR TITLE
hotifx(gatsby): disabled gatsby offline plugin

### DIFF
--- a/gatsby/config/gatsby-config.ts
+++ b/gatsby/config/gatsby-config.ts
@@ -197,7 +197,8 @@ const config = {
         display: 'block',
       },
     },
-    `gatsby-plugin-offline`,
+    // TODO: enable after resolving /sw.js mimetype problem
+    // `gatsby-plugin-offline`,
     {
       resolve: `gatsby-plugin-google-gtag`,
       options: {


### PR DESCRIPTION
* due problem with `/sw.js` mimetype 
![image](https://user-images.githubusercontent.com/6154740/98485067-6858a280-221c-11eb-8070-9c3df533385c.png)
![image](https://user-images.githubusercontent.com/6154740/98485070-6b539300-221c-11eb-8347-2b4ffe29dcd6.png)
