### PR TITLE
Gatsby: graphql types CI

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Run eslint check
         run: yarn lint:eslint
 
-      - name: Run typescript check
-        run: yarn lint:tsc
-
       - name: Run stylelint check
         run: yarn lint:styles
 
       - name: Build frontend
         run: yarn build
+
+      - name: Run typescript check
+        run: yarn lint:tsc

--- a/gatsby/src/components/footer/footer.tsx
+++ b/gatsby/src/components/footer/footer.tsx
@@ -5,7 +5,7 @@ import I18n, { gLang } from '@/components/i18n';
 
 import styles from './footer.module.scss';
 import { graphql, useStaticQuery } from 'gatsby';
-import { IFooterLinksQuery } from 'graphql-types';
+import { IFooterLinksQuery } from '@graphql-types';
 
 const DRUPAL_INTERNAL_IDS = {
   USEFUL_LINKS_1: '1',

--- a/gatsby/src/components/guide/guide.tsx
+++ b/gatsby/src/components/guide/guide.tsx
@@ -1,6 +1,6 @@
 import useMobile from '@/hooks/useMobile';
 import classNames from 'classnames';
-import { IArea, IMeasure } from 'graphql-types';
+import { IArea, IMeasure } from '@graphql-types';
 import React from 'react';
 import Button from '../button';
 import Col from '../col';

--- a/gatsby/src/components/header/header-locale-select.tsx
+++ b/gatsby/src/components/header/header-locale-select.tsx
@@ -4,7 +4,7 @@ import { TRoute } from '@/components/i18n';
 import Link from '@/components/link';
 
 import classes from './header-locale-select.module.scss';
-import { ISitePageContextLanguageVariants } from 'graphql-types';
+import { ISitePageContextLanguageVariants } from '@graphql-types';
 
 interface IProps {
   languageVariants: ISitePageContextLanguageVariants;

--- a/gatsby/src/components/header/header.tsx
+++ b/gatsby/src/components/header/header.tsx
@@ -12,7 +12,7 @@ import headerLogoCS from './header-logo-cs.svg';
 import headerLogoEN from './header-logo-en.svg';
 import { HeaderLocaleSelect } from './header-locale-select';
 import I18n, { TRoute } from '@/components/i18n';
-import { ISitePageContext } from 'graphql-types';
+import { ISitePageContext } from '@graphql-types';
 
 interface NavItem {
   label: string;

--- a/gatsby/src/components/marker/marker.tsx
+++ b/gatsby/src/components/marker/marker.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Room, Event } from '@material-ui/icons';
-import { IRegion } from 'graphql-types';
+import { IRegion } from '@graphql-types';
 import Time from '../time';
 import I18n from '../i18n';
 

--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import I18n from '@/components/i18n';
 import Link from '@/components/link';
 
-import { IMeasureDetailFragment } from 'graphql-types';
+import { IMeasureDetailFragment } from '@graphql-types';
 import { graphql } from 'gatsby';
 import TopicDetail from '../topic-detail';
 import { RegionsMarker, TimeMarker } from '../marker';

--- a/gatsby/src/components/measure-list/measure-list.tsx
+++ b/gatsby/src/components/measure-list/measure-list.tsx
@@ -1,5 +1,5 @@
 import useMobile from '@/hooks/useMobile';
-import { IMeasure } from 'graphql-types';
+import { IMeasure } from '@graphql-types';
 import React from 'react';
 import Measure from './measure';
 

--- a/gatsby/src/components/related-measure/related-measure.tsx
+++ b/gatsby/src/components/related-measure/related-measure.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IRelatedMeasureFragment } from 'graphql-types';
+import { IRelatedMeasureFragment } from '@graphql-types';
 import { graphql, Link } from 'gatsby';
 import { RegionsMarker, TimeMarker } from '../marker';
 

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -6,7 +6,7 @@ import I18n from '@/components/i18n';
 
 import Accordion from '../accordion';
 import ContentBox from '../content-box';
-import { ISituationDetailFragment } from 'graphql-types';
+import { ISituationDetailFragment } from '@graphql-types';
 import { graphql } from 'gatsby';
 import TopicDetail from '../topic-detail';
 import RelatedMeasure from '../related-measure';

--- a/gatsby/src/components/situations-box/situation.tsx
+++ b/gatsby/src/components/situations-box/situation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from '@/components/link';
 import { KeyboardArrowRight } from '@material-ui/icons';
 import styles from './situation.module.scss';
-import { IArea } from 'graphql-types';
+import { IArea } from '@graphql-types';
 import ContentIcon from '@/components/content-icon/content-icon';
 
 interface Props {

--- a/gatsby/src/components/situations-box/situations-box.tsx
+++ b/gatsby/src/components/situations-box/situations-box.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Situation from '@/components/situations-box/situation';
 import styles from './situations-box.module.scss';
-import { ISituation } from 'graphql-types';
+import { ISituation } from '@graphql-types';
 
 interface IProps {
   situations: ISituation[];

--- a/gatsby/src/layouts/default-layout.tsx
+++ b/gatsby/src/layouts/default-layout.tsx
@@ -8,7 +8,7 @@ import Header from '@/components/header';
 import Footer from '@/components/footer';
 import I18n from '@/components/i18n';
 import styles from './default-layout.module.scss';
-import { ISitePageContext } from 'graphql-types';
+import { ISitePageContext } from '@graphql-types';
 
 interface IProps {
   children: ReactElement[];

--- a/gatsby/src/pages/404.tsx
+++ b/gatsby/src/pages/404.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { vh90 } from './404.module.scss';
 import Layout from '@/layouts/default-layout';
 import { Helmet } from 'react-helmet';
-import { ISitePageContext } from 'graphql-types';
+import { ISitePageContext } from '@graphql-types';
 
 interface IProps {
   pageContext: ISitePageContext;

--- a/gatsby/src/templates/custom-page/custom-page.tsx
+++ b/gatsby/src/templates/custom-page/custom-page.tsx
@@ -1,4 +1,4 @@
-import { IPage, IQuery, ISitePageContext } from 'graphql-types';
+import { IPage, IQuery, ISitePageContext } from '@graphql-types';
 
 import { SchemaComp } from '@/components/schema/schema';
 import { SEO as Seo } from 'gatsby-plugin-seo';

--- a/gatsby/src/templates/lists/index.tsx
+++ b/gatsby/src/templates/lists/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import Container from '@/components/container';
 import I18n from '@/components/i18n';
-import { IQuery, ISitePageContext } from 'graphql-types';
+import { IQuery, ISitePageContext } from '@graphql-types';
 import Layout from '@/layouts/default-layout';
 import { Guide } from '@/components/guide';
 import DesktopTopContent from '@/components/desktop-top-content';

--- a/gatsby/src/templates/lists/measures.tsx
+++ b/gatsby/src/templates/lists/measures.tsx
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby';
 import ContentBox from '@/components/content-box';
 import Container from '@/components/container';
 import { SEO as Seo } from 'gatsby-plugin-seo';
-import { IMeasureTypeQueryQuery, ISitePageContext } from 'graphql-types';
+import { IMeasureTypeQueryQuery, ISitePageContext } from '@graphql-types';
 import Breadcrumb from '@/components/breadcrumb';
 import Headline from '@/components/headline';
 import CategoryItem from '@/components/category-item';

--- a/gatsby/src/templates/lists/situations.tsx
+++ b/gatsby/src/templates/lists/situations.tsx
@@ -3,7 +3,7 @@ import { SEO as Seo } from 'gatsby-plugin-seo';
 import { graphql } from 'gatsby';
 import ContentBox from '@/components/content-box';
 import Container from '@/components/container';
-import { ISituationTypeQueryQuery, ISitePageContext } from 'graphql-types';
+import { ISituationTypeQueryQuery, ISitePageContext } from '@graphql-types';
 import Breadcrumb from '@/components/breadcrumb';
 import Headline from '@/components/headline';
 import CategoryItem from '@/components/category-item';

--- a/gatsby/src/templates/measures/list.tsx
+++ b/gatsby/src/templates/measures/list.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { IQuery, ISitePageContext } from 'graphql-types';
+import { IQuery, ISitePageContext } from '@graphql-types';
 
 import { SEO as Seo } from 'gatsby-plugin-seo';
 import Container from '@/components/container';

--- a/gatsby/src/templates/measures/page.tsx
+++ b/gatsby/src/templates/measures/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { IMeasurePageQueryQuery, ISitePageContext } from 'graphql-types';
+import { IMeasurePageQueryQuery, ISitePageContext } from '@graphql-types';
 import { SchemaComp } from '@/components/schema/schema';
 import { SEO as Seo } from 'gatsby-plugin-seo';
 import Layout from '@/layouts/default-layout';

--- a/gatsby/src/templates/situations/list.tsx
+++ b/gatsby/src/templates/situations/list.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { IQuery, ISitePageContext } from 'graphql-types';
+import { IQuery, ISitePageContext } from '@graphql-types';
 import Container from '@/components/container';
 
 import { SEO as Seo } from 'gatsby-plugin-seo';

--- a/gatsby/src/templates/situations/page.tsx
+++ b/gatsby/src/templates/situations/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { IQuery, ISitePageContext } from 'graphql-types';
+import { IQuery, ISitePageContext } from '@graphql-types';
 import Layout from '@/layouts/default-layout';
 import SituationDetail from '@/components/situation-detail/situation-detail';
 import ContentBox from '@/components/content-box';

--- a/gatsby/tsconfig.json
+++ b/gatsby/tsconfig.json
@@ -13,7 +13,8 @@
     "downlevelIteration": true,
     "baseUrl": "./",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@graphql-types": ["./graphql-types.ts"]
     },
     "types": ["node", "react", "jest", "testing-library__jest-dom"]
   },


### PR DESCRIPTION
- added alias to generated graphql types: `@graphql-types` so it does not seem like a package
- running typescript check only after build so the `graphql-types.ts` file is ready