### PR TITLE
Gatsby/fix: removed the fixed height from guide elements to improve accessibility

### DIFF
--- a/gatsby/src/components/guide/guide-item.tsx
+++ b/gatsby/src/components/guide/guide-item.tsx
@@ -35,7 +35,7 @@ const GuideItem: React.FC<IProps> = ({
     <>
       <Col col={12} colSm={6} colLg={4} className="box">
         <div className="box__inner">
-          <div style={{ height: '74px' }} className="d-flex flex-row">
+          <div className="d-flex flex-row">
             {iconCode && (
               <ContentIcon
                 code={iconCode}
@@ -85,7 +85,6 @@ const GuideItem: React.FC<IProps> = ({
               className={classNames(classes.guideItemDescriptionText, {
                 [classes.guideItemDescriptionTextBlue]: variant === 'white',
               })}
-              style={{ height: '40px' }}
             >
               {description}
             </p>


### PR DESCRIPTION
The fixed height is not necessary anymore as we truncate the text via `-webkit-line-clamp`

Fixes:
https://trello.com/c/SH1a1yEK/219-user-font-size

How to test:
I used this extension for Chrome: https://chrome.google.com/webstore/detail/a%20-fontsize-changer-lite/ckihgechpahhpompcinglebkgcdgpkil?hl=en
clicked through all of the app and other screens look pretty much ok.