### PR TITLE
external link icon is no more underlined

### DIFF
--- a/gatsby/assets/scss/design-system/base/_master.scss
+++ b/gatsby/assets/scss/design-system/base/_master.scss
@@ -449,6 +449,11 @@ a {
 			top: 50%;
 			margin-top: -( 10px / 2 );
 		}
+		&::after {
+			position: absolute;
+			bottom: 0.5em;
+			margin-top: -( 10px / 2 );
+		}
 	}
 
 	&.with-icon,
@@ -511,6 +516,7 @@ a {
 		&::after {
 			margin-left: ( $spacer / 6 );
 			content: '\e909';
+      display: inline-block;
 		}
 	}
 


### PR DESCRIPTION
Small issue with external icon underline fixed

fixes:
[https://trello.com/c/Z4uI7Q0O/250-opravit-vzhled-odkazu](https://trello.com/c/Z4uI7Q0O/250-opravit-vzhled-odkazu)

Test:
 external link icon is not underlined - hovered or not
 external link icon does not overflow on a next row and stays stick right after the last link word