### PR TITLE
gatsby/fix: added latin-ext subset to roboto google font

### DIFF
--- a/gatsby/config/gatsby-config.ts
+++ b/gatsby/config/gatsby-config.ts
@@ -215,6 +215,7 @@ const config = {
           {
             family: `Roboto`,
             variants: ['300', '400', '500', '700'],
+            subsets: ['latin-ext'],
           },
         ],
       },


### PR DESCRIPTION
added missing subset (although by the plugin docs it says its by default) 🤷‍♂️ 