### PR TITLE
fix: Gatsby GraphQL queries now respect current language

### DIFF
--- a/gatsby/config/create-pages.ts
+++ b/gatsby/config/create-pages.ts
@@ -225,7 +225,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
           component: subTmpl,
           context: {
             slug: subNode.path.alias,
-            langCode: subNode.path.langcode,
+            langCode: subNode.langcode,
             languageVariants,
           },
         });

--- a/gatsby/config/create-pages.ts
+++ b/gatsby/config/create-pages.ts
@@ -116,14 +116,16 @@ export const createPages: GatsbyNode['createPages'] = async ({
 
   const pathLangPrefix = (lang) => (lang === 'cs' ? '' : '/' + lang);
 
-  const generateLanguageVariants = (nodes, toLanguage, filter) => nodes
-    // include variants with different language and matching node filter (drupal_id/target)
-    .filter((item) => item.langcode != toLanguage && filter(item))
-    // reduce variants to mapping {[language]: /path}
-    .reduce((acc, item) => {
-      acc[item.langcode] = pathLangPrefix(item.langcode) + (item.target || item.path?.alias);
-      return acc;
-    }, {});
+  const generateLanguageVariants = (nodes, toLanguage, filter) =>
+    nodes
+      // include variants with different language and matching node filter (drupal_id/target)
+      .filter((item) => item.langcode != toLanguage && filter(item))
+      // reduce variants to mapping {[language]: /path}
+      .reduce((acc, item) => {
+        acc[item.langcode] =
+          pathLangPrefix(item.langcode) + (item.target || item.path?.alias);
+        return acc;
+      }, {});
 
   languages.forEach((lang) => {
     const pathPrefix = pathLangPrefix(lang);
@@ -144,7 +146,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
       const languageVariants = generateLanguageVariants(
         translations,
         lang,
-        (i) => i.source === source
+        (i) => i.source === source,
       );
 
       createPage({
@@ -165,7 +167,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
     const languageVariants = generateLanguageVariants(
       customPages,
       page.langcode,
-      (p) => p.drupal_id == page.drupal_id
+      (p) => p.drupal_id == page.drupal_id,
     );
 
     const pathPrefix = pathLangPrefix(page.langcode);
@@ -183,14 +185,22 @@ export const createPages: GatsbyNode['createPages'] = async ({
   // Create blog posts pages.
   const blogPostSpecs = [
     ['situation', result.data.allArea.edges, listTemplate[0], pageTemplate[0]],
-    ['measure', result.data.allMeasureType.edges, listTemplate[1], pageTemplate[1]],
+    [
+      'measure',
+      result.data.allMeasureType.edges,
+      listTemplate[1],
+      pageTemplate[1],
+    ],
   ];
   blogPostSpecs.forEach((spec) => {
     const [key, posts, itemTmpl, subTmpl] = spec;
-    const nodes = posts.map(p => p.node);
+    const nodes = posts.map((p) => p.node);
 
     // extract all subnodes from all nodes and flats them to one dimensional array
-    const flattenedSubNodes = nodes.map(n => n.relationships[key]).flat().filter(Boolean);
+    const flattenedSubNodes = nodes
+      .map((n) => n.relationships[key])
+      .flat()
+      .filter(Boolean);
 
     nodes.forEach((node) => {
       const pathPrefix = pathLangPrefix(node.langcode);
@@ -198,8 +208,8 @@ export const createPages: GatsbyNode['createPages'] = async ({
       const languageVariants = generateLanguageVariants(
         nodes,
         node.langcode,
-        (n) => n.drupal_id === node.drupal_id
-      )
+        (n) => n.drupal_id === node.drupal_id,
+      );
 
       createPage({
         path: pathPrefix + node.path.alias,
@@ -217,7 +227,7 @@ export const createPages: GatsbyNode['createPages'] = async ({
         const languageVariants = generateLanguageVariants(
           flattenedSubNodes,
           subNode.langcode,
-          (n) => n.drupal_id === subNode.drupal_id
+          (n) => n.drupal_id === subNode.drupal_id,
         );
 
         createPage({

--- a/gatsby/src/templates/custom-page/custom-page.tsx
+++ b/gatsby/src/templates/custom-page/custom-page.tsx
@@ -57,7 +57,7 @@ export default CustomPage;
 
 export const query = graphql`
   query($slug: String!, $langCode: String!) {
-    page(path: { alias: { eq: $slug } }) {
+    page(path: { alias: { eq: $slug }, langcode: { eq: $langCode } }) {
       id
       content {
         processed

--- a/gatsby/src/templates/measures/list.tsx
+++ b/gatsby/src/templates/measures/list.tsx
@@ -76,8 +76,8 @@ const Home: React.FC<IProps> = ({ data, pageContext }) => {
 export default Home;
 
 export const query = graphql`
-  query($slug: String!) {
-    measureType(path: { alias: { eq: $slug } }) {
+  query MeasuresListQuery($slug: String!, $langCode: String!) {
+    measureType(path: { alias: { eq: $slug }, langcode: { eq: $langCode } }) {
       name
       relationships {
         measure {

--- a/gatsby/src/templates/measures/page.tsx
+++ b/gatsby/src/templates/measures/page.tsx
@@ -56,8 +56,8 @@ const Page: React.FC<IProps> = ({ data, pageContext }) => {
 export default Page;
 
 export const query = graphql`
-  query MeasurePageQuery($slug: String!) {
-    measure(path: { alias: { eq: $slug } }) {
+  query MeasurePageQuery($slug: String!, $langCode: String!) {
+    measure(path: { alias: { eq: $slug }, langcode: { eq: $langCode } }) {
       title
       meta_description
       content: description {

--- a/gatsby/src/templates/situations/list.tsx
+++ b/gatsby/src/templates/situations/list.tsx
@@ -81,8 +81,8 @@ const SituationList: React.FC<IProps> = ({ data, pageContext }) => {
 export default SituationList;
 
 export const query = graphql`
-  query($slug: String!) {
-    area(path: { alias: { eq: $slug } }) {
+  query($slug: String!, $langCode: String!) {
+    area(path: { alias: { eq: $slug }, langcode: { eq: $langCode } }) {
       name
       relationships {
         situation {

--- a/gatsby/src/templates/situations/page.tsx
+++ b/gatsby/src/templates/situations/page.tsx
@@ -74,8 +74,8 @@ const Page: React.FC<IProps> = ({ data, pageContext }) => {
 export default Page;
 
 export const query = graphql`
-  query($slug: String!) {
-    situation(path: { alias: { eq: $slug } }) {
+  query($slug: String!, $langCode: String!) {
+    situation(path: { alias: { eq: $slug }, langcode: { eq: $langCode } }) {
       title
       meta_description
       content {


### PR DESCRIPTION
* https://trello.com/c/c3B2EPwD/249-zm%C4%9Bnit-identifik%C3%A1tor-pro-graphql-na-generovan%C3%BDch-str%C3%A1nk%C3%A1ch
* added `$langCode` to all queries asking for content from GraphQL (no more conflicts `/cookies` vs. `/en/cookies`)