### PR TITLE
fix: Gatsby: desktop top content height

### DIFF
--- a/gatsby/src/components/desktop-top-content/desktop-top-content.module.scss
+++ b/gatsby/src/components/desktop-top-content/desktop-top-content.module.scss
@@ -1,3 +1,7 @@
+.desktopTopContent {
+  height: 250px;
+}
+
 .title {
   color: #fff;
   font-weight: 300;

--- a/gatsby/src/components/desktop-top-content/desktop-top-content.module.scss
+++ b/gatsby/src/components/desktop-top-content/desktop-top-content.module.scss
@@ -1,5 +1,7 @@
 .desktopTopContent {
-  height: 250px;
+  @media (min-width: 992px) and (min-height: 450px) {
+    height: 250px;
+  }
 }
 
 .title {

--- a/gatsby/src/components/desktop-top-content/desktop-top-content.module.scss.d.ts
+++ b/gatsby/src/components/desktop-top-content/desktop-top-content.module.scss.d.ts
@@ -1,2 +1,3 @@
+export const desktopTopContent: string;
 export const title: string;
 export const subtitle: string;

--- a/gatsby/src/components/desktop-top-content/desktop-top-content.tsx
+++ b/gatsby/src/components/desktop-top-content/desktop-top-content.tsx
@@ -32,7 +32,7 @@ const DesktopTopContent: React.FC<IProps> = ({
           'justify-content-center',
           'align-items-center',
         )}
-        style={{ height: 250 }}
+        style={{ height: '250px' }}
       >
         {title && <h2 className={classes.title}>{title}</h2>}
         {showSearch && (

--- a/gatsby/src/components/desktop-top-content/desktop-top-content.tsx
+++ b/gatsby/src/components/desktop-top-content/desktop-top-content.tsx
@@ -1,4 +1,3 @@
-import useMobile from '@/hooks/useMobile';
 import classNames from 'classnames';
 import React from 'react';
 import Col from '../col';
@@ -17,12 +16,6 @@ const DesktopTopContent: React.FC<IProps> = ({
   subtitle,
   showSearch = true,
 }) => {
-  const isMobile = useMobile();
-
-  if (isMobile) {
-    return null;
-  }
-
   return (
     <>
       <div

--- a/gatsby/src/components/desktop-top-content/desktop-top-content.tsx
+++ b/gatsby/src/components/desktop-top-content/desktop-top-content.tsx
@@ -31,8 +31,8 @@ const DesktopTopContent: React.FC<IProps> = ({
           'flex-column',
           'justify-content-center',
           'align-items-center',
+          classes.desktopTopContent,
         )}
-        style={{ height: '250px' }}
       >
         {title && <h2 className={classes.title}>{title}</h2>}
         {showSearch && (


### PR DESCRIPTION
https://trello.com/c/xBqOvQLB/300-content-margin-on-desktop?menu=filter&filter=label:Frontend