### PR TITLE
feat/gatsby: drupal data dev mode cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 If you only want to run frontend part of this app, you **dont have to install Docker** and the backend part. It works standalone as well - see the frontend  for more details
 
-- 🚀 [see how to get up and running with the frontend](https://github.com/cesko-digital/covid.gov.cz/tree/master/gatsby#gatsby) ➡️ 
+- 🚀 [see how to get up and running with the frontend](/gatsby/README.md#gatsby) ➡️ 
   
 
 ### Backend - Drupal

--- a/gatsby/README.md
+++ b/gatsby/README.md
@@ -25,6 +25,7 @@
 ### How does it work?
 
 1. Upon running the gatsby build/dev, it first downloads all of the data from Drupal prod env (you will see the requests in your console).
+   (it will only download the data once, and that use those until you clean Gatsby cache by `yarn dev:clean`, or set your env variable `SHOULD_REFRESH_DRUPAL_DATA` to `1` if you always want to have fresh Drupal data)
 2. Gatsby then stores this data locally and offers a GraphQL on top of that data.
 3. You can browse all of the data to be used in components later in [GraphiQL](http://localhost:8000/___graphql)
 4. Sometimes the dev env halts, solution is usually to stop and run `yarn dev` again. We will eventually fix that, _but feel free to fix it and create a PR_ 🤗

--- a/gatsby/gatsby-source-drupal/gatsby-node.js
+++ b/gatsby/gatsby-source-drupal/gatsby-node.js
@@ -53,8 +53,6 @@ exports.sourceNodes = async (
   const shouldRefresh = Boolean(process.env.SHOULD_REFRESH_DRUPAL_DATA);
   const lastFetched = await cache.get('lastFetched');
 
-  console.log({shouldRefresh, lastFetched});
-
   if(!shouldRefresh && lastFetched){
     // Touch nodes so they are not garbage collected by Gatsby.
     getNodes().forEach((node) => {
@@ -64,8 +62,11 @@ exports.sourceNodes = async (
         });
       }
     }); // Process sync data from Drupal.
-    console.log(`Last Drupal data fetched already on ${new Date().toLocaleString()}, skipping the data pull.`);
-    console.log(`Clear the Gatsby cache if you want to pull the new data or run TODO`);
+    
+    console.log(chalk.green(`--------------------------------------------------------------------------------------------`));
+    console.log(chalk.green(`Last Drupal data fetched already on ${new Date().toLocaleString()}, skipping the data pull.`));
+    console.log(chalk.gray(`Clear the Gatsby cache by running `, chalk.black.bgGray('yarn dev:clean') , ` if you want to pull the new data, or set the SHOULD_REFRESH_DRUPAL_DATA variable`));
+    console.log(chalk.green(`--------------------------------------------------------------------------------------------`));
     return;
   }
   

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -59,6 +59,7 @@
     "babel-eslint": "^10.0.3",
     "babel-jest": "^26.6.1",
     "babel-preset-gatsby": "^0.5.14",
+    "chalk": "^4.1.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-config-standard": "^14.1.0",

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "gatsby clean && gatsby build",
     "dev": "gatsby develop",
+    "dev:clean": "gatsby clean && gatsby develop",
     "dev:local": "gatsby develop -H 0.0.0.0",
     "format:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,json,md}\"",


### PR DESCRIPTION
- by default now, when running `yarn dev` it will download the drupal data just once
- to get fresh drupal data basically just run `yarn dev:clean`, or set your env variable `SHOULD_REFRESH_DRUPAL_DATA` to `1` and have it refreshed every single time
- all of the steps to get new data are documented

Why?
- the data pull takes the most time for the dev version to compile and its rarely required to update them