### PR TITLE
situation and measure detail as in figma styled

### DIFF
--- a/gatsby/assets/scss/custom-variables.scss
+++ b/gatsby/assets/scss/custom-variables.scss
@@ -76,6 +76,7 @@ ol {
   margin: 0;
   padding: 0;
   margin-left: 15px;
+  margin-bottom: 15px;
 
   & > li {
     margin-bottom: 4px;

--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -5,7 +5,6 @@ import Link from '@/components/link';
 import { IMeasureDetailFragment } from '@graphql-types';
 import { graphql } from 'gatsby';
 import TopicDetail from '../topic-detail';
-import { RegionsMarker, TimeMarker } from '../marker';
 import { useTranslation } from '../i18n';
 
 interface IProps {
@@ -15,29 +14,15 @@ interface IProps {
 const MeasureDetail: React.FC<IProps> = ({ measure }) => {
   const { t } = useTranslation();
   const hasSourceLink = Boolean(measure.source);
-  const hasRegion = Boolean(measure.relationships.region.length);
-  const hasTimeConstraint = Boolean(measure.valid_from || measure.valid_to);
   return (
     <TopicDetail
       title={measure.title}
       subtitle={measure.norm}
       processedContent={measure?.content?.processed}
+      validFrom={measure?.valid_from}
+      validTo={measure?.valid_to}
+      region={measure?.relationships?.region}
     >
-      {(hasRegion || hasTimeConstraint) && (
-        <div className="mt-2">
-          <h3 className="mb-1 color-blue-dark">{t('location_validity')}</h3>
-          {hasRegion && (
-            <RegionsMarker regions={measure.relationships.region} />
-          )}
-          {hasTimeConstraint && (
-            <TimeMarker
-              displayTime
-              validFrom={measure.valid_from}
-              validTo={measure.valid_to}
-            />
-          )}
-        </div>
-      )}
       {hasSourceLink && (
         <div className="mt-2">
           <hr />

--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -6,6 +6,7 @@ import { IMeasureDetailFragment } from '@graphql-types';
 import { graphql } from 'gatsby';
 import TopicDetail from '../topic-detail';
 import { useTranslation } from '../i18n';
+import { RegionsMarker, TimeMarker } from '../marker';
 
 interface IProps {
   measure: IMeasureDetailFragment;
@@ -14,27 +15,40 @@ interface IProps {
 const MeasureDetail: React.FC<IProps> = ({ measure }) => {
   const { t } = useTranslation();
   const hasSourceLink = Boolean(measure.source);
+  const hasRegion = Boolean(measure?.relationships?.region?.length);
+  const hasTimeConstraint = Boolean(measure?.valid_from || measure?.valid_to);
+
   return (
-    <TopicDetail
-      title={measure.title}
-      subtitle={measure.norm}
-      processedContent={measure?.content?.processed}
-      validFrom={measure?.valid_from}
-      validTo={measure?.valid_to}
-      region={measure?.relationships?.region}
-    >
-      {hasSourceLink && (
-        <div className="mt-2">
-          <hr />
-          <h3 className="mb-1 color-blue-dark">{t('related')}</h3>
-          <div>
-            <Link className="color-blue mb-1" to={measure.source.uri}>
-              {measure.source.title}
-            </Link>
+    <>
+      <TopicDetail
+        title={measure.title}
+        subtitle={measure.norm}
+        processedContent={measure?.content?.processed}
+      />
+      <div className="bg-white mb-3 pb-2 pb-md-0 px-2 px-md-3">
+        {hasRegion && (
+          <RegionsMarker regions={measure?.relationships?.region} />
+        )}
+        {hasTimeConstraint && (
+          <TimeMarker
+            displayTime
+            validFrom={measure?.valid_from}
+            validTo={measure?.valid_to}
+          />
+        )}
+        {hasSourceLink && (
+          <div className="pt-2">
+            <hr />
+            <h3 className="mb-1 color-blue-dark">{t('related')}</h3>
+            <div>
+              <Link className="color-blue mb-1" to={measure.source.uri}>
+                {measure.source.title}
+              </Link>
+            </div>
           </div>
-        </div>
-      )}
-    </TopicDetail>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -36,6 +36,9 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
         title={situation.title}
         titleIconCode={iconCode}
         processedContent={situation?.content?.processed}
+        validFrom={situation?.valid_from}
+        validTo={situation?.valid_to}
+        region={situation?.relationships?.region}
       >
         {hasRelatedMeasures && (
           <div className="mt-2">

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -36,12 +36,10 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
         title={situation.title}
         titleIconCode={iconCode}
         processedContent={situation?.content?.processed}
-        validFrom={situation?.valid_from}
-        validTo={situation?.valid_to}
-        region={situation?.relationships?.region}
-      >
+      />
+      <div className="bg-white mb-3 pb-2 pb-md-0 px-2 px-md-3">
         {hasRelatedMeasures && (
-          <div className="mt-2">
+          <div className="pt-2">
             <hr />
             <h3 className="mb-1 color-blue-dark">{t('related_measures')}</h3>
             {situation.relationships.measures.map((measure) => (
@@ -50,7 +48,7 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
           </div>
         )}
         {hasRelatedLinks && (
-          <div className="mt-2">
+          <div className="pt-2">
             <hr />
             <h3 className="mb-1 color-blue-dark">{t('related')}</h3>
             <div>
@@ -64,7 +62,7 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
             </div>
           </div>
         )}
-      </TopicDetail>
+      </div>
       <Container>
         {hasFaq && (
           <ContentBox variant="blue" title={t('faq')} boldedTitleCount={2}>

--- a/gatsby/src/components/subtitle/subtitle.module.scss
+++ b/gatsby/src/components/subtitle/subtitle.module.scss
@@ -1,5 +1,7 @@
+@import '../../../assets/scss/design-system/base/variables';
+
 .subtitle {
   font-size: 1.7rem;
-  margin-bottom: 2.2rem;
-  color: black;
+  margin-bottom: 2rem;
+  color: $theme-blue-dark;
 }

--- a/gatsby/src/components/topic-detail/topic-detail.module.scss
+++ b/gatsby/src/components/topic-detail/topic-detail.module.scss
@@ -1,5 +1,18 @@
+@import '../../../assets/scss/design-system/base/variables';
+
 .topicDetail {
   h2 {
     font-weight: 500;
+
+    strong {
+      font-weight: 400;
+    }
+  }
+}
+
+.article {
+  h2 {
+    font-weight: 400;
+    color: $theme-blue;
   }
 }

--- a/gatsby/src/components/topic-detail/topic-detail.module.scss.d.ts
+++ b/gatsby/src/components/topic-detail/topic-detail.module.scss.d.ts
@@ -1,1 +1,2 @@
 export const topicDetail: string;
+export const article: string;

--- a/gatsby/src/components/topic-detail/topic-detail.tsx
+++ b/gatsby/src/components/topic-detail/topic-detail.tsx
@@ -4,12 +4,17 @@ import Headline from '@/components/headline';
 import Subtitle from '@/components/subtitle';
 
 import styles from './topic-detail.module.scss';
+import { RegionsMarker, TimeMarker } from '../marker';
+import { IRegion } from '../../../graphql-types';
 
 interface IProps {
   title: string;
   titleIconCode?: string;
   processedContent: string;
   subtitle?: string;
+  validFrom?: string;
+  validTo?: string;
+  region?: Pick<IRegion, 'name'>[];
 }
 
 const TopicDetail: React.FC<IProps> = ({
@@ -18,17 +23,31 @@ const TopicDetail: React.FC<IProps> = ({
   processedContent,
   children,
   subtitle,
+  validFrom,
+  validTo,
+  region,
 }) => {
+  const hasRegion = Boolean(region?.length);
+  const hasTimeConstraint = Boolean(validFrom || validTo);
+
   return (
     <div className={styles.topicDetail}>
       <Headline iconCode={titleIconCode}>{title}</Headline>
-      <article className="bg-white rounded p-2 p-md-3 pb-3 mb-1">
+      <article className="bg-white rounded px-2 pb-2 px-md-3 pb-md-3 pt-md-0 pt-3 mb-1">
+        <hr className="mt-0 mb-2 d-none d-md-block" />
         {subtitle && <Subtitle>{subtitle}</Subtitle>}
         <div
+          className={styles.article}
           dangerouslySetInnerHTML={{
             __html: processedContent,
           }}
         />
+        <div className="my-md-3">
+          {hasRegion && <RegionsMarker regions={region} />}
+          {hasTimeConstraint && (
+            <TimeMarker displayTime validFrom={validFrom} validTo={validTo} />
+          )}
+        </div>
         {children}
       </article>
     </div>

--- a/gatsby/src/components/topic-detail/topic-detail.tsx
+++ b/gatsby/src/components/topic-detail/topic-detail.tsx
@@ -33,7 +33,7 @@ const TopicDetail: React.FC<IProps> = ({
   return (
     <div className={styles.topicDetail}>
       <Headline iconCode={titleIconCode}>{title}</Headline>
-      <article className="bg-white rounded px-2 pb-2 px-md-3 pb-md-3 pt-md-0 pt-3 mb-1">
+      <article className="bg-white rounded px-2 pb-2 px-md-3 pb-md-3 pt-md-0 pt-2 mb-1">
         <hr className="mt-0 mb-2 d-none d-md-block" />
         {subtitle && <Subtitle>{subtitle}</Subtitle>}
         <div

--- a/gatsby/src/components/topic-detail/topic-detail.tsx
+++ b/gatsby/src/components/topic-detail/topic-detail.tsx
@@ -4,54 +4,33 @@ import Headline from '@/components/headline';
 import Subtitle from '@/components/subtitle';
 
 import styles from './topic-detail.module.scss';
-import { RegionsMarker, TimeMarker } from '../marker';
-import { IRegion } from '../../../graphql-types';
 
 interface IProps {
   title: string;
   titleIconCode?: string;
   processedContent: string;
   subtitle?: string;
-  validFrom?: string;
-  validTo?: string;
-  region?: Pick<IRegion, 'name'>[];
 }
 
 const TopicDetail: React.FC<IProps> = ({
   title,
   titleIconCode,
   processedContent,
-  children,
   subtitle,
-  validFrom,
-  validTo,
-  region,
-}) => {
-  const hasRegion = Boolean(region?.length);
-  const hasTimeConstraint = Boolean(validFrom || validTo);
-
-  return (
-    <div className={styles.topicDetail}>
-      <Headline iconCode={titleIconCode}>{title}</Headline>
-      <article className="bg-white rounded px-2 pb-2 px-md-3 pb-md-3 pt-md-0 pt-2 mb-1">
-        <hr className="mt-0 mb-2 d-none d-md-block" />
-        {subtitle && <Subtitle>{subtitle}</Subtitle>}
-        <div
-          className={styles.article}
-          dangerouslySetInnerHTML={{
-            __html: processedContent,
-          }}
-        />
-        <div className="my-md-3">
-          {hasRegion && <RegionsMarker regions={region} />}
-          {hasTimeConstraint && (
-            <TimeMarker displayTime validFrom={validFrom} validTo={validTo} />
-          )}
-        </div>
-        {children}
-      </article>
-    </div>
-  );
-};
+}) => (
+  <div className={styles.topicDetail}>
+    <Headline iconCode={titleIconCode}>{title}</Headline>
+    <article className="bg-white rounded px-2 pb-2 px-md-3 pb-md-3 pt-md-0 pt-2">
+      <hr className="mt-0 mb-2 d-none d-md-block" />
+      {subtitle && <Subtitle>{subtitle}</Subtitle>}
+      <div
+        className={styles.article}
+        dangerouslySetInnerHTML={{
+          __html: processedContent,
+        }}
+      />
+    </article>
+  </div>
+);
 
 export default TopicDetail;


### PR DESCRIPTION
I have changed the styling to fit according to Figma. It is not possible to put the region and time marker below the heading since it is a part of the article so it would need to be parsed (I feel it is nonsense). Therefore I put it below the article as it is everywhere else.

Done: 
https://trello.com/b/XOOBy51q/covidgovcz

To test:
measure and situation details look more like in Figma.