### PR TITLE
feat: last updated label

### DIFF
--- a/gatsby/assets/scss/design-system/base/_variables.scss
+++ b/gatsby/assets/scss/design-system/base/_variables.scss
@@ -20,6 +20,7 @@ $theme-yellow:                #ecae1a !default;
 $theme-red:                   #e04857 !default;
 $theme-gray-dark:             #3b3b3b !default;
 $theme-gray:                  #707070 !default;
+$theme-gray-lighter:          #AFAFAF !default;
 $theme-gray-lighten:          #e1e1e1 !default;
 $theme-gray-light:            #f5f5f5 !default;
 

--- a/gatsby/src/components/last-update/index.ts
+++ b/gatsby/src/components/last-update/index.ts
@@ -1,0 +1,1 @@
+export { default } from './last-update';

--- a/gatsby/src/components/last-update/last-update.module.scss
+++ b/gatsby/src/components/last-update/last-update.module.scss
@@ -1,0 +1,20 @@
+@import '../../../assets/scss/design-system/base/variables';
+@import '../../../assets/scss/design-system/vendor/bootstrap/functions';
+@import '../../../assets/scss/design-system/vendor/bootstrap/mixins';
+@import '../../../assets/scss/design-system/vendor/bootstrap/variables';
+
+.lastUpdate {
+  text-align: right;
+  padding-right: 0;
+  padding-left: 0;
+  padding-bottom: 1rem;
+  color: $theme-white;
+
+  @include media-breakpoint-up(md) {
+    text-align: left;
+    padding-right: 3rem;
+    padding-left: 3rem;
+    padding-bottom: 0;
+    color: $theme-gray-lighter;
+  }
+}

--- a/gatsby/src/components/last-update/last-update.module.scss.d.ts
+++ b/gatsby/src/components/last-update/last-update.module.scss.d.ts
@@ -1,0 +1,1 @@
+export const lastUpdate: string;

--- a/gatsby/src/components/last-update/last-update.tsx
+++ b/gatsby/src/components/last-update/last-update.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { Maybe, Scalars } from '../../../graphql-types';
+import { useTranslation } from '../i18n';
+import Time from '../time';
+
+import styles from './last-update.module.scss';
+
+interface Props {
+  lastUpdated: Maybe<Scalars['Date']>;
+}
+
+const LastUpdate: React.FC<Props> = ({ lastUpdated }) => {
+  const { t } = useTranslation();
+  return (
+    <div className={classNames(styles.lastUpdate)}>
+      <Time
+        prefix={`${t('last_updated')} `}
+        displayTime
+        datetime={lastUpdated}
+      />
+    </div>
+  );
+};
+
+export default LastUpdate;

--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -21,6 +21,7 @@ const MeasureDetail: React.FC<IProps> = ({ measure }) => {
     <TopicDetail
       title={measure.title}
       subtitle={measure.norm}
+      lastUpdated={measure?.last_updated}
       processedContent={measure?.content?.processed}
     >
       {(hasRegion || hasTimeConstraint) && (
@@ -84,6 +85,7 @@ export const query = graphql`
     changed
     valid_from
     valid_to
+    last_updated
   }
 `;
 

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -31,7 +31,6 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
     situation.relationships?.icon?.code ||
     situation.relationships?.situation_type?.relationships?.icon?.code;
 
-
   return (
     <>
       <TopicDetail

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -31,7 +31,6 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
     situation.relationships?.icon?.code ||
     situation.relationships?.situation_type?.relationships?.icon?.code;
 
-  console.log(situation);
 
   return (
     <>

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -30,11 +30,14 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
     situation.relationships?.icon?.code ||
     situation.relationships?.situation_type?.relationships?.icon?.code;
 
+  console.log(situation);
+
   return (
     <>
       <TopicDetail
         title={situation.title}
         titleIconCode={iconCode}
+        lastUpdated={situation?.last_updated}
         processedContent={situation?.content?.processed}
       >
         {hasRelatedMeasures && (
@@ -136,6 +139,7 @@ export const query = graphql`
     changed
     valid_from
     valid_to
+    last_updated
   }
 `;
 

--- a/gatsby/src/components/topic-detail/topic-detail.tsx
+++ b/gatsby/src/components/topic-detail/topic-detail.tsx
@@ -4,11 +4,14 @@ import Headline from '@/components/headline';
 import Subtitle from '@/components/subtitle';
 
 import styles from './topic-detail.module.scss';
+import LastUpdate from '../last-update';
+import { Maybe, Scalars } from '../../../graphql-types';
 
 interface IProps {
   title: string;
   titleIconCode?: string;
   processedContent: string;
+  lastUpdated: Maybe<Scalars['Date']>;
   subtitle?: string;
 }
 
@@ -17,11 +20,13 @@ const TopicDetail: React.FC<IProps> = ({
   titleIconCode,
   processedContent,
   children,
+  lastUpdated,
   subtitle,
 }) => {
   return (
     <div className={styles.topicDetail}>
       <Headline iconCode={titleIconCode}>{title}</Headline>
+      <LastUpdate lastUpdated={lastUpdated} />
       <article className="bg-white rounded p-2 p-md-3 pb-3 mb-1">
         {subtitle && <Subtitle>{subtitle}</Subtitle>}
         <div


### PR DESCRIPTION
The final result differs a bit according to the design in figma. It's because The design does not count with incredibly huge titles. In these cases, it would need special behavior and it does not make sense to have the last update next to the title for small titles and below for the long ones. So I put it right after.

Solves:
https://trello.com/c/u6QK295g/278-add-last-updated-info

To test:
Last update info displays on all measures & situations details.