### PR TITLE
gatsby/fix: background position fixed after using new logo (without beta badge)

### DIFF
--- a/gatsby/src/layouts/default-layout.module.scss
+++ b/gatsby/src/layouts/default-layout.module.scss
@@ -75,7 +75,7 @@
         object-position: center -75px !important;
         left: 50% !important;
         transform: translateX(-50%) !important;
-        top: 85px !important;
+        top: 70px !important;
       }
     }
   }


### PR DESCRIPTION
After merging https://github.com/cesko-digital/covid.gov.cz/pull/370
Fixes:
![image](https://user-images.githubusercontent.com/19856731/99312312-2227c280-285e-11eb-941c-fccdd431a8c9.png)
