### PR TITLE
gatsby/fix: desktop css enchancements

### DIFF
--- a/gatsby/src/components/guide/guide.module.scss
+++ b/gatsby/src/components/guide/guide.module.scss
@@ -1,4 +1,7 @@
 @import '../../../assets/scss/design-system/base/variables';
+@import '../../../assets/scss/design-system/vendor/bootstrap/functions';
+@import '../../../assets/scss/design-system/vendor/bootstrap/mixins';
+@import '../../../assets/scss/design-system/vendor/bootstrap/variables';
 
 /* purgecss start ignore */
 .guide {
@@ -9,6 +12,11 @@
 
   &--white {
     background-color: #fff;
+  }
+
+  // desktop
+  @include media-breakpoint-up(md) {
+    padding: 24px 28px;
   }
 }
 

--- a/gatsby/src/components/measure-list/measure.module.scss
+++ b/gatsby/src/components/measure-list/measure.module.scss
@@ -1,8 +1,16 @@
 @import '../../../assets/scss/design-system/base/variables';
+@import '../../../assets/scss/design-system/vendor/bootstrap/functions';
+@import '../../../assets/scss/design-system/vendor/bootstrap/mixins';
+@import '../../../assets/scss/design-system/vendor/bootstrap/variables';
 
 .measure {
   border-top: 1px solid rgba(35, 98, 162, 0.3);
   padding: 1.6rem 0;
+
+  // desktop
+  @include media-breakpoint-up(md) {
+    border-top: none;
+  }
 }
 
 .measureTitle {


### PR DESCRIPTION
fixes:
![image](https://user-images.githubusercontent.com/19856731/99315574-21ddf600-2863-11eb-94c6-c69bc197eb2f.png)
+ adds a bit of of bigger padding on desktop version for the guide