### PR TITLE
gatsby/feat: dev search index

### DIFF
--- a/gatsby/config/gatsby-node.ts
+++ b/gatsby/config/gatsby-node.ts
@@ -106,6 +106,11 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = ({
   actions,
   getNode,
 }) => {
+  const existingSearchIndex = getNode(SEARCH_INDEX_ID);
+  if (existingSearchIndex) {
+    actions.touchNode({ nodeId: existingSearchIndex.id });
+  }
+
   if (INDEXED_TYPES.indexOf(node.internal.type) === -1) {
     return;
   }


### PR DESCRIPTION
Problem:
- when using `yarn dev` where it does not need to redoownload fresh data every single run, it would removoe the site search index, therefore crashing the dev build

Solution:
- touch the existing search index, so its not garbagee collected when using cached gatsby data