### PR TITLE
gastby/fix: Offset of main photo by 1 px from left

### DIFF
--- a/gatsby/src/layouts/default-layout.module.scss
+++ b/gatsby/src/layouts/default-layout.module.scss
@@ -80,8 +80,6 @@
 
       @include media-breakpoint-up(xs) {
         object-position: center -75px !important;
-        left: 50% !important;
-        transform: translateX(-50%) !important;
         top: 70px !important;
       }
     }


### PR DESCRIPTION
Resolves bug with the main photo space of 1px from the left side of the screen.

https://trello.com/c/1ZigUX44/281-mezi-okrajem-str%C3%A1nky-a-obr%C3%A1zkem-je-1-pixel