### PR TITLE
Gatsby fix measure version source

### DIFF
--- a/gatsby/src/components/category-item-list/category-item-list.module.scss
+++ b/gatsby/src/components/category-item-list/category-item-list.module.scss
@@ -28,6 +28,11 @@
       color: $theme-white;
     }
   }
+
+  .linkBack span,
+  .chevron {
+    color: $theme-blue !important;
+  }
 }
 
 .blueTheme {
@@ -49,6 +54,11 @@
     i {
       color: $theme-white;
     }
+  }
+
+  .linkBack span,
+  .chevron {
+    color: $theme-yellow !important;
   }
 }
 
@@ -84,7 +94,6 @@
     }
 
     .chevron {
-      color: $theme-yellow;
       margin-left: -4px;
     }
 
@@ -98,10 +107,6 @@
       font-weight: 500;
       letter-spacing: 0.5px;
       margin-bottom: 12px;
-
-      span {
-        color: $theme-yellow !important;
-      }
 
       &:hover {
         span {

--- a/gatsby/src/components/measure-detail/measure-detail.tsx
+++ b/gatsby/src/components/measure-detail/measure-detail.tsx
@@ -20,9 +20,7 @@ interface IProps {
 
 const MeasureDetail: React.FC<IProps> = ({ measure }) => {
   const { t } = useTranslation();
-  const hasSourceLink = Boolean(measure.source);
   const hasRegion = Boolean(measure?.relationships?.region?.length);
-  const hasTimeConstraint = Boolean(measure?.valid_from || measure?.valid_to);
   const { hash } = useLocation();
   const hasMounted = useHasMounted();
   const {
@@ -31,6 +29,10 @@ const MeasureDetail: React.FC<IProps> = ({ measure }) => {
     nextVersionFrom,
     nextVersionHash,
   } = getCurrentMeasureVersion(hasMounted ? hash : '', measure);
+  const hasSourceLink = Boolean(versionToDisplay.source);
+  const hasTimeConstraint = Boolean(
+    versionToDisplay?.valid_from || versionToDisplay?.valid_to,
+  );
 
   return (
     <>
@@ -120,8 +122,11 @@ const MeasureDetail: React.FC<IProps> = ({ measure }) => {
             <hr />
             <h3 className="mb-1 color-blue-dark">{t('related')}</h3>
             <div>
-              <Link className="color-blue mb-1" to={measure.source.uri}>
-                {measure.source.title}
+              <Link
+                className="color-blue mb-1"
+                to={versionToDisplay.source.uri}
+              >
+                {versionToDisplay.source.title}
               </Link>
             </div>
           </div>
@@ -166,6 +171,10 @@ export const query = graphql`
         }
         valid_from
         valid_to
+        source {
+          uri
+          title
+        }
       }
     }
     path {

--- a/gatsby/src/components/situation-detail/situation-detail.tsx
+++ b/gatsby/src/components/situation-detail/situation-detail.tsx
@@ -46,6 +46,7 @@ const SituationDetail: React.FC<IProps> = ({ situation }) => {
         beforeContent={
           hasUpdate && (
             <UpdateWarning
+              className="pb-2"
               variant="info"
               title={reactStringReplace(
                 t('situation_valid_from_header').replace(


### PR DESCRIPTION
Changes:

* `gatsby/src/components/category-item-list/category-item-list.module.scss` – measure category link color fixed (back button); it's minor fix of an issue I noticed; [check here](https://covid-gov-cz-git-gatsby-fixmeasure-version-source.ceskodigital.vercel.app/opatreni/maloobchod-sluzby/narizeni-pro-provozovatele-obchodu-provozoven-sluzeb) (zpět na aktuální opatření was yellow, now it's blue)
* `gatsby/src/components/measure-detail/measure-detail.tsx` – that's the reason of this PR; [check here](https://covid-gov-cz-git-gatsby-fixmeasure-version-source.ceskodigital.vercel.app/opatreni/skolstvi/omezeni-provozu-vysokych-skol)
* `gatsby/src/components/situation-detail/situation-detail.tsx` – I just added some padding 😄 