### PR TITLE
gastby/fix: Main photo overflows footer if content is too short

### DIFF
--- a/gatsby/src/layouts/default-layout.module.scss
+++ b/gatsby/src/layouts/default-layout.module.scss
@@ -7,6 +7,7 @@
   background: #e5e5e5;
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
 }
 
 .main {

--- a/gatsby/src/layouts/default-layout.module.scss
+++ b/gatsby/src/layouts/default-layout.module.scss
@@ -7,7 +7,6 @@
   background: #e5e5e5;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
 }
 
 .main {
@@ -31,6 +30,7 @@
   width: 100%;
   height: auto !important;
   backface-visibility: hidden;
+  max-height: 100%;
 
   &.searchDisplayed {
     // additional top position when search on mobile is visible


### PR DESCRIPTION
Fix for the case when the main photo overflows footer when the main content of the page is missing or is too short.

https://trello.com/c/8DFudfvs/320-obr%C3%A1zek-na-pozad%C3%AD-p%C5%99et%C3%A9k%C3%A1