### PR TITLE
gatsby/fix: Main photo resizes on mobile on keyboard open

### DIFF
--- a/gatsby/src/layouts/default-layout.module.scss
+++ b/gatsby/src/layouts/default-layout.module.scss
@@ -50,7 +50,7 @@
   }
 
   @include media-breakpoint-up(xs) {
-    height: 55vh !important;
+    height: 100vw !important;
   }
 
   @include media-breakpoint-up(md) {


### PR DESCRIPTION
Fix for resizing of the main photo on mobile when focused on the search bar and keyboard is opened.

https://trello.com/c/vRxEnr8L/325-389-bug-mobile-image-resizes-when-search-in-focus-with-keyboard-opened

Resolves #389