### PR TITLE
gatsby/fix: breadcrumb overflow

### DIFF
--- a/gatsby/assets/scss/design-system/components/_breadcrumbs.scss
+++ b/gatsby/assets/scss/design-system/components/_breadcrumbs.scss
@@ -16,7 +16,8 @@
 		display: none;
 		color: $theme-blue;
 		@include reset-pa-ma();
-		@include text-truncate;
+    @include text-truncate;
+    white-space: normal;
 		padding-top: ( $spacer / 12 );
 		padding-bottom: ( $spacer / 12 );
 


### PR DESCRIPTION
Fixed breadcrumb overflow by overwriting white-space property set by text-truncate mixin (instead of changing text-truncate mixin to not cause bugs elsewhere)




Before             |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/37017937/105641407-06efb980-5e84-11eb-9ad9-898e6d498c46.png" width="227">  |  <img src="https://user-images.githubusercontent.com/37017937/105641402-fb9c8e00-5e83-11eb-872b-429b106c127d.png" width="227">